### PR TITLE
Api caller optional params

### DIFF
--- a/EPCData.API/EpcDataApiCallerService.cs
+++ b/EPCData.API/EpcDataApiCallerService.cs
@@ -8,14 +8,14 @@ namespace EPCData.API
 {
     public class EpcDataApiCallerService : IEpcDataApiCallerService
     {
-        private const string EpcDataApiUrl = "https://dceas-user-site-staging.cloudapps.digital/api/epc";
+        private const string EPC_DATA_API_URL = "https://dceas-user-site-staging.cloudapps.digital/api/epc";
         private readonly IRestClient client;
 
         public EpcDataApiCallerService()
         {
             client = new RestClient
             {
-                BaseUrl = new Uri(EpcDataApiUrl)
+                BaseUrl = new Uri(EPC_DATA_API_URL)
             };
         }
 

--- a/EPCData.API/RequestParameters.cs
+++ b/EPCData.API/RequestParameters.cs
@@ -1,28 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace EPCData.API
 {
     public class RequestParameters
     {
-        private const string PostcodeParameterName = "postcode";
-        private const string SizeParameterName = "size";
-        private const int SizeMinValue = 1;
-        private const int SizeMaxValue = 100;
+        private const string POSTCODE_PARAMETER_NAME = "postcode";
+        private const string SIZE_PARAMETER_NAME = "size";
+        private const int SIZE_MIN_VALUE = 1;
+        private const int SIZE_MAX_VALUE = 100;
 
         public SingleRequestParameter Postcode { get; }
         public SingleRequestParameter Size { get; }
-        public IEnumerable<SingleRequestParameter> OptionalParameters { get; }
 
-        public RequestParameters(
-            string postcode, 
-            int size, 
-            IEnumerable<SingleRequestParameter> optionalParameters = null)
+        public RequestParameters(string postcode, int size)
         {
             Postcode = GetPostcodeParameter(postcode);
             Size = GetSizeParameter(size);
-            OptionalParameters = optionalParameters ?? new List<SingleRequestParameter>();
         }
 
         private static SingleRequestParameter GetPostcodeParameter(string postcode)
@@ -34,17 +28,17 @@ namespace EPCData.API
 
             var postcodeValue = Regex.Replace(postcode, @"\s+", "");
 
-            return new SingleRequestParameter(PostcodeParameterName, postcodeValue);
+            return new SingleRequestParameter(POSTCODE_PARAMETER_NAME, postcodeValue);
         }
         
         private static SingleRequestParameter GetSizeParameter(int size)
         {
-            if (size < SizeMinValue || size > SizeMaxValue)
+            if (size < SIZE_MIN_VALUE || size > SIZE_MAX_VALUE)
             {
-                throw new ArgumentException($"Provided size value of {size} was outside the accepted range of {SizeMinValue} and {SizeMaxValue}.");
+                throw new ArgumentException($"Provided size value of {size} was outside the accepted range of {SIZE_MIN_VALUE} and {SIZE_MAX_VALUE}.");
             }
 
-            return new SingleRequestParameter(SizeParameterName, size.ToString());
+            return new SingleRequestParameter(SIZE_PARAMETER_NAME, size.ToString());
         }
     }
 }

--- a/EPCPortalTesting/EPCData.API.IntegationTests/EpcDataApiCallerServiceTests.cs
+++ b/EPCPortalTesting/EPCData.API.IntegationTests/EpcDataApiCallerServiceTests.cs
@@ -15,8 +15,8 @@ namespace EPCPortalTesting.EPCData.API.IntegationTests
             public string PropertyNotFoundInResponse { get; set; }
         }
 
-        private const string ValidPostcode = "NW5 2TA";
-        private const int ValidSize = 1;
+        private const string VALIDPOSTCODE = "NW5 2TA";
+        private const int VALIDSIZE = 1;
 
         private IEpcDataApiCallerService service;
 
@@ -30,53 +30,55 @@ namespace EPCPortalTesting.EPCData.API.IntegationTests
         public async Task ExecuteRequestAsync_GivenInvalidPostcodeButValidSize_ThenDataReturnedIsNull()
         {
             const string postcode = "Invalid Postcode";
-            var parameters = new RequestParameters(postcode, ValidSize);
+            var parameters = new RequestParameters(postcode, VALIDSIZE);
 
-            var data = await service.ExecuteRequestAsync<TestDataModel>(parameters);
+            var epcResponseResults = await service.ExecuteRequestAsync<TestDataModel>(parameters);
 
-            data.Should().BeNullOrEmpty();
+            epcResponseResults.Should().BeNullOrEmpty();
         }
 
         [Test]
         public async Task ExecuteRequestAsync_GivenValidPostcodeAndSize_ThenDataReturnedIsNotNull()
         {
-            var parameters = new RequestParameters(ValidPostcode, ValidSize);
+            var parameters = new RequestParameters(VALIDPOSTCODE, VALIDSIZE);
 
-            var data = await service.ExecuteRequestAsync<TestDataModel>(parameters);
+            var epcResponseResults = await service.ExecuteRequestAsync<TestDataModel>(parameters);
 
-            data.Should().NotBeNullOrEmpty();
+            epcResponseResults.Should().NotBeNullOrEmpty();
         }
 
         [Test]
         public async Task ExecuteRequestAsync_GivenValidPostcodeAndSize_ThenPropertyThatDoesNotMapToResponseIsNull()
         {
-            var parameters = new RequestParameters(ValidPostcode, ValidSize);
+            var parameters = new RequestParameters(VALIDPOSTCODE, VALIDSIZE);
 
-            var data = await service.ExecuteRequestAsync<TestDataModel>(parameters);
+            var epcResponseResults = await service.ExecuteRequestAsync<TestDataModel>(parameters);
+            var firstResult = epcResponseResults.ElementAt(0);
 
-            data.ElementAt(0).PropertyNotFoundInResponse.Should().BeNull();
+            firstResult.PropertyNotFoundInResponse.Should().BeNull();
         }
 
         [Test]
-        public async Task ExecuteRequestAsync_GivenValidPostcodeAndSize_ThenPropertyThatMapsToResponseIsNotNull()
+        public async Task ExecuteRequestAsync_GivenValidPostcodeAndSize_ThenPropertyThatMapsToResponseHasExpectedValue()
         {
-            var parameters = new RequestParameters(ValidPostcode, ValidSize);
+            var parameters = new RequestParameters(VALIDPOSTCODE, VALIDSIZE);
 
-            var data = await service.ExecuteRequestAsync<TestDataModel>(parameters);
+            var epcResponseResults = await service.ExecuteRequestAsync<TestDataModel>(parameters);
+            var firstResult = epcResponseResults.ElementAt(0);
 
-            data.ElementAt(0).Postcode.Should().Be(ValidPostcode);
+            firstResult.Postcode.Should().Be(VALIDPOSTCODE);
         }
 
         [Test]
         public async Task ExecuteRequestAsync_GivenValidPostcodeWith10OrMoreAddressesAndSizeIs10_Then10ResultsShouldBeReturned()
         {
             const string postcode = "E6 1BJ";
-            const int size = 10;
-            var parameters = new RequestParameters(postcode, size);
+            const int addressCount = 10;
+            var parameters = new RequestParameters(postcode, addressCount);
 
-            var data = await service.ExecuteRequestAsync<TestDataModel>(parameters);
+            var epcResponseResults = await service.ExecuteRequestAsync<TestDataModel>(parameters);
 
-            data.Should().HaveCount(size);
+            epcResponseResults.Should().HaveCount(addressCount);
         }
     }
 }


### PR DESCRIPTION
Removed optional parameters from RequestParameters class, as it seems we don't need it.